### PR TITLE
setting DLL visibility flags when building on Windows

### DIFF
--- a/src/qtsoap.pri
+++ b/src/qtsoap.pri
@@ -11,6 +11,6 @@ qtsoap-uselib:!qtsoap-buildlib {
 }
 
 win32 {
-    contains(TEMPLATE, lib):contains(CONFIG, shared):DEFINES += QT_QTSOAP_EXPORT
-    else:qtsoap-uselib:DEFINES += QT_QTSOAP_IMPORT
+    contains(TEMPLATE, lib):contains(CONFIG, shared):DEFINES += QtSOAP_EXPORTS
+    else:qtsoap-uselib:DEFINES += QT_QTSOAP_EXPORT=Q_DECL_IMPORT
 }


### PR DESCRIPTION
## Windows linking issue

The visibility flags seem to fail in the non-library linking and building qtsoap.obj locally in your project mode.

Linking in library mode seems to work:

<pre>
CONFIG += qtsoap-uselib
include(../QtSOAP/src/qtsoap.pri)
</pre>


after building the DLLS in `QtSoap\build` beforehand.
