### PR TITLE
COMP: Fix -fpermissive error

### DIFF
--- a/src/qtsoap.h
+++ b/src/qtsoap.h
@@ -155,7 +155,7 @@ private:
 class QT_QTSOAP_EXPORT QtSoapQName
 {
 public:
-    QtSoapQName(const QString &name = QString::QString(), const QString &uri = QString::QString());
+    QtSoapQName(const QString &name = QString(), const QString &uri = QString());
     ~QtSoapQName();
 
     QtSoapQName &operator =(const QString &s);
@@ -430,7 +430,7 @@ public:
     const QtSoapType &method() const;
     const QtSoapType &returnValue() const;
     void setMethod(const QtSoapQName &);
-    void setMethod(const QString &name, const QString &url = QString::QString());
+    void setMethod(const QString &name, const QString &url = QString());
     void addMethodArgument(QtSoapType *);
     void addMethodArgument(const QString &uri, const QString &name, const QString &value);
     void addMethodArgument(const QString &uri, const QString &name, bool value, int dummy);


### PR DESCRIPTION
This commit fixes a regression introduced in 81dc56d (removed deprecated QString::null).

It fixes errors like the following:

```
  /path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.h:433:79: error: cannot call constructor ‘QString::QString’ directly [-fpermissive]
    433 |     void setMethod(const QString &name, const QString &url = QString::QString());
        |
```