### PR TITLE
BUG: Correctly parse structures even if first child is not element

### DIFF
--- a/src/qtsoap.cpp
+++ b/src/qtsoap.cpp
@@ -2997,7 +2997,14 @@ QtSmartPtr<QtSoapType> QtSoapTypeFactory::soapType(QDomNode node) const
 
     if (attr.isNull() || !constructor) {
         QHash<QString, QtSoapTypeConstructorBase *>::ConstIterator it;
-	if (node.firstChild().isElement()) {
+        bool hasElemNode = false;
+        for (int i = 0; i < node.childNodes().count(); i++) {
+            if (node.childNodes().at(i).isElement()) {
+                hasElemNode = true;
+                break;
+            }
+        }
+        if (hasElemNode) {
             if (localName(node.nodeName().toLower()) == "array") {
                 it = typeHandlers.find("array");
             } else


### PR DESCRIPTION
We may have comment or processing instruction as first child, so iterate over all children and try to find element child. Abort iteration if such child is found