### PR TITLE
COMP: Remove deprecated use of QLinkedList in Qt >= 5.15

### DIFF
--- a/src/qtsoap.cpp
+++ b/src/qtsoap.cpp
@@ -2902,11 +2902,25 @@ void QtSoapMessage::addMethodArgument(const QString &name, const QString &uri, i
 QtSoapTypeFactory::QtSoapTypeFactory()
 {
     QtSoapTypeConstructor<QtSoapStruct> *structConstructor = new QtSoapTypeConstructor<QtSoapStruct>();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    deleteList.push_back(structConstructor);
+#else
     deleteList.append(structConstructor);
+#endif
+
     QtSoapTypeConstructor<QtSoapArray> *arrayConstructor = new QtSoapTypeConstructor<QtSoapArray>();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    deleteList.push_back(arrayConstructor);
+#else
     deleteList.append(arrayConstructor);
+#endif
+
     QtSoapTypeConstructor<QtSoapSimpleType> *basicTypeConstructor = new QtSoapTypeConstructor<QtSoapSimpleType>();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    deleteList.push_back(basicTypeConstructor);
+#else
     deleteList.append(basicTypeConstructor);
+#endif
 
     registerHandler("struct", structConstructor);
     registerHandler("array", arrayConstructor);
@@ -2947,7 +2961,11 @@ QtSoapTypeFactory::QtSoapTypeFactory()
 */
 QtSoapTypeFactory::~QtSoapTypeFactory()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    std::list<QtSoapTypeConstructorBase*>::const_iterator it = deleteList.begin();
+#else
     QLinkedList<QtSoapTypeConstructorBase*>::ConstIterator it = deleteList.begin();
+#endif
     while (it != deleteList.end()) {
         delete *it;
         ++it;

--- a/src/qtsoap.h
+++ b/src/qtsoap.h
@@ -45,8 +45,16 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtCore/QUrl>
 #include <QtCore/QHash>
+// Use of QLinkedList is superseded by std::list
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
 #include <QtCore/QLinkedList>
+#endif
 #include <QtCore/QPointer>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+#include <list>
+#endif
+
 
 #if defined(Q_OS_WIN) || defined(Q_OS_SYMBIAN)
   #if defined(QtSOAP_EXPORTS)
@@ -556,7 +564,11 @@ public:
 private:
     mutable QString errorStr;
     QHash<QString, QtSoapTypeConstructorBase *> typeHandlers;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+    std::list<QtSoapTypeConstructorBase*> deleteList;
+#else
     QLinkedList<QtSoapTypeConstructorBase*> deleteList;
+#endif
 };
 
 class QT_QTSOAP_EXPORT QtSoapNamespaces


### PR DESCRIPTION
This commit fixes warnings like the following:

```
In file included from /path/to/CTK-Qt5-build/QtSOAP/src/QtSoapStruct:1,
                 from /path/to/CTK/Plugins/org.commontk.dah.core/ctkDicomAppHostingTypesHelper.h:27,
                 from /path/to/CTK/Plugins/org.commontk.dah.core/ctkDicomAppHostingTypesHelper.cpp:22:
/path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.h:559:5: warning: ‘template<class T> class QLinkedList’ is deprecated: Use std::list instead [-Wdeprecated-declarations]
  559 |     QLinkedList<QtSoapTypeConstructorBase*> deleteList;
      |     ^~~~~~~~~~~
```

From Qt 5.15 documentation:

> Note: This class is obsolete, please use std::list instead.

See https://doc.qt.io/qt-5/qlinkedlist.html#details