### PR TITLE
COMP: Remove deprecated use of QString::sprintf with Qt >= 5.15

### DIFF
--- a/src/qtsoap.cpp
+++ b/src/qtsoap.cpp
@@ -2448,8 +2448,13 @@ bool QtSoapMessage::setContent(const QByteArray &buffer)
     if (!doc.setContent(buffer, true, &errorMsg,
                         &errorLine, &errorColumn)) {
         QString s;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+        s = "%1 at line %2, column %3";
+        s = s.arg(errorMsg.toLatin1().constData()).arg(errorLine).arg(errorColumn);
+#else
         s.sprintf("%s at line %i, column %i", errorMsg.toLatin1().constData(),
                   errorLine, errorColumn);
+#endif
         setFaultCode(VersionMismatch);
         setFaultString("XML parse error");
         addFaultDetail(new QtSoapSimpleType(QtSoapQName("ParseError"), s));


### PR DESCRIPTION
This commit fixes the following warning:

```
/path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.cpp: In member function ‘bool QtSoapMessage::setContent(const QByteArray&)’: /path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.cpp:2456:41: warning: ‘QString& QString::sprintf(const char*, ...)’ is deprecated: Use asprintf(), arg() or QTextStream instead [-Wdeprecated-declarations]
 2456 |                   errorLine, errorColumn);
      |                                         ^
In file included from /path/to/Qt/5.15.2/gcc_64/include/QtCore/QString:1,
                 from /path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.h:42,
                 from /path/to/CTK-Qt5-build/QtSOAP/src/qtsoap.cpp:40:
/path/to/Qt/5.15.2/gcc_64/include/QtCore/qstring.h:393:14: note: declared here
  393 |     QString &sprintf(const char *format, ...) Q_ATTRIBUTE_FORMAT_PRINTF(2, 3);
      |              ^~~~~~~
```