### PR TITLE
COMP: Update CMake minimum required version from 2.8.12 to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.0)
+
 set(QtSOAP_QT_VERSION "4" CACHE STRING "Expected Qt version")
 mark_as_advanced(QtSOAP_QT_VERSION)
 
@@ -8,11 +10,8 @@ if(NOT (QtSOAP_QT_VERSION VERSION_EQUAL "4" OR QtSOAP_QT_VERSION VERSION_EQUAL "
 endif()
 
 if(QtSOAP_QT_VERSION VERSION_GREATER "4")
-  cmake_minimum_required(VERSION 2.8.12)
   set(QT5_INSTALL_PREFIX "" CACHE PATH "The install location of Qt5")
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT5_INSTALL_PREFIX})
-else()
-  cmake_minimum_required(VERSION 2.8.2)
 endif()
 
 project(QtSOAP)


### PR DESCRIPTION
The selected version matches the CTK requirements.

If also fixes the following warning by ensuring the policy CMP0048 is implicitly set to NEW:

```
CMake Warning (dev) at CMakeLists.txt:18 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```